### PR TITLE
Change vendor name from webkit to apple for standards position

### DIFF
--- a/combined-schema.gen.json
+++ b/combined-schema.gen.json
@@ -191,7 +191,7 @@
           "type": "string",
           "enum": [
             "mozilla",
-            "webkit"
+            "apple"
           ]
         },
         "url": {

--- a/mappings/combined-data.json
+++ b/mappings/combined-data.json
@@ -70,7 +70,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/166",
         "position": "support",
         "concerns": []
@@ -143,7 +143,7 @@
     },
     "standards-positions": [
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/347",
         "position": "oppose",
         "concerns": [
@@ -261,7 +261,7 @@
     },
     "standards-positions": [
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/266",
         "position": "support",
         "concerns": []
@@ -532,7 +532,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/167",
         "position": "support",
         "concerns": []
@@ -705,7 +705,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/11",
         "position": "neutral",
         "concerns": [
@@ -823,7 +823,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/370",
         "position": "support",
         "concerns": [
@@ -1289,7 +1289,7 @@
     },
     "standards-positions": [
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/319",
         "position": "support",
         "concerns": []
@@ -1428,7 +1428,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/180",
         "concerns": [],
         "position": ""
@@ -1698,7 +1698,7 @@
   "background-clip-border-area": {
     "standards-positions": [
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/379",
         "position": "support",
         "concerns": []
@@ -1760,7 +1760,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/149",
         "concerns": [
           "privacy",
@@ -1949,7 +1949,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/118",
         "position": "",
         "concerns": []
@@ -2194,7 +2194,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/300",
         "position": "",
         "concerns": []
@@ -2446,7 +2446,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/348",
         "position": "",
         "concerns": []
@@ -2938,7 +2938,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/230",
         "position": "blocked",
         "concerns": []
@@ -3030,7 +3030,7 @@
   "clipboard-custom-format": {
     "standards-positions": [
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/43",
         "position": "",
         "concerns": []
@@ -3159,7 +3159,7 @@
     },
     "standards-positions": [
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/215",
         "position": "neutral",
         "concerns": []
@@ -3414,7 +3414,7 @@
   "colrv1": {
     "standards-positions": [
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/415",
         "position": "",
         "concerns": []
@@ -3529,7 +3529,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/376",
         "position": "support",
         "concerns": []
@@ -3617,7 +3617,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/255",
         "position": "oppose",
         "concerns": [
@@ -3712,7 +3712,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/42",
         "position": "support",
         "concerns": [
@@ -3816,7 +3816,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/205",
         "position": "neutral",
         "concerns": []
@@ -4094,7 +4094,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/57",
         "position": "support",
         "concerns": []
@@ -4360,7 +4360,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/36",
         "position": "support",
         "concerns": [
@@ -4404,7 +4404,7 @@
   "corner-shape": {
     "standards-positions": [
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/229",
         "position": "support",
         "concerns": []
@@ -4646,7 +4646,7 @@
     ],
     "standards-positions": [
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/193",
         "position": "support",
         "concerns": []
@@ -4678,7 +4678,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/288",
         "position": "",
         "concerns": []
@@ -4743,7 +4743,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/355",
         "position": "support",
         "concerns": []
@@ -4780,7 +4780,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/77",
         "position": "support",
         "concerns": []
@@ -4986,7 +4986,7 @@
         ]
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/386",
         "position": "support",
         "concerns": []
@@ -5015,7 +5015,7 @@
     },
     "standards-positions": [
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/97",
         "position": "oppose",
         "concerns": []
@@ -5308,7 +5308,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/12",
         "position": "support",
         "concerns": [
@@ -5757,7 +5757,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/209",
         "position": "support",
         "concerns": []
@@ -5822,7 +5822,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/328",
         "position": "",
         "concerns": []
@@ -6052,7 +6052,7 @@
     ],
     "standards-positions": [
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/329",
         "position": "support",
         "concerns": []
@@ -6140,7 +6140,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/147",
         "position": "support",
         "concerns": []
@@ -6194,7 +6194,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/164",
         "position": "neutral",
         "concerns": [
@@ -6332,7 +6332,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/301",
         "position": "support",
         "concerns": []
@@ -6403,7 +6403,7 @@
         ]
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/41",
         "concerns": [
           "portability",
@@ -6460,7 +6460,7 @@
   "dom": {
     "standards-positions": [
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/375",
         "position": "support",
         "concerns": []
@@ -6607,7 +6607,7 @@
         ]
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/243",
         "position": "",
         "concerns": []
@@ -6694,7 +6694,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/84",
         "position": "",
         "concerns": []
@@ -6814,7 +6814,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/420",
         "concerns": [
           "duplication",
@@ -7127,7 +7127,7 @@
         "position": ""
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/29",
         "concerns": [
           "API design",
@@ -7227,7 +7227,7 @@
         ]
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/173",
         "position": "blocked",
         "concerns": []
@@ -7414,7 +7414,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/85",
         "position": "support",
         "concerns": [
@@ -7472,7 +7472,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/231",
         "position": "support",
         "concerns": []
@@ -7660,7 +7660,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/28",
         "position": "oppose",
         "concerns": [
@@ -8031,7 +8031,7 @@
     },
     "standards-positions": [
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/556",
         "position": "",
         "concerns": []
@@ -8146,7 +8146,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/276",
         "position": "",
         "concerns": []
@@ -8634,7 +8634,7 @@
     ],
     "standards-positions": [
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/47",
         "position": "support",
         "concerns": []
@@ -8831,7 +8831,7 @@
   "gamepad-vr": {
     "standards-positions": [
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/1",
         "position": "support",
         "concerns": [
@@ -8867,7 +8867,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/444",
         "position": "",
         "concerns": []
@@ -8900,7 +8900,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/32",
         "position": "oppose",
         "concerns": [
@@ -9218,7 +9218,7 @@
     },
     "standards-positions": [
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/347",
         "position": "oppose",
         "concerns": [
@@ -9440,7 +9440,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/404",
         "position": "support",
         "concerns": []
@@ -9567,7 +9567,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/246",
         "position": "support",
         "concerns": []
@@ -9632,7 +9632,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/3",
         "position": "support",
         "concerns": []
@@ -10134,7 +10134,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/453",
         "position": "",
         "concerns": []
@@ -10394,7 +10394,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/39",
         "position": "support",
         "concerns": []
@@ -10617,7 +10617,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/94",
         "position": "support",
         "concerns": []
@@ -11017,7 +11017,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/348",
         "position": "",
         "concerns": []
@@ -11288,7 +11288,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/264",
         "position": "support",
         "concerns": []
@@ -11641,7 +11641,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/182",
         "concerns": [
           "compatibility",
@@ -11807,7 +11807,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/242",
         "position": "",
         "concerns": []
@@ -12110,7 +12110,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/130",
         "position": "support",
         "concerns": []
@@ -12468,7 +12468,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/283",
         "position": "",
         "concerns": []
@@ -12503,7 +12503,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/52",
         "position": "",
         "concerns": []
@@ -12738,7 +12738,7 @@
     ],
     "standards-positions": [
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/105",
         "position": "support",
         "concerns": []
@@ -13251,7 +13251,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/124",
         "position": "support",
         "concerns": []
@@ -13289,7 +13289,7 @@
     },
     "standards-positions": [
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/81",
         "position": "support",
         "concerns": []
@@ -13346,7 +13346,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/187",
         "position": "support",
         "concerns": []
@@ -13523,7 +13523,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/34",
         "position": "support",
         "concerns": []
@@ -13667,7 +13667,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/369",
         "position": "support",
         "concerns": []
@@ -14029,7 +14029,7 @@
         "position": ""
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/292",
         "position": "support",
         "concerns": [
@@ -14306,7 +14306,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/413",
         "position": "support",
         "concerns": []
@@ -14341,7 +14341,7 @@
     },
     "standards-positions": [
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/347",
         "position": "oppose",
         "concerns": [
@@ -14504,7 +14504,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/427",
         "position": "",
         "concerns": []
@@ -14575,7 +14575,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/169",
         "position": "",
         "concerns": []
@@ -14967,7 +14967,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/50",
         "position": "support",
         "concerns": [
@@ -15087,7 +15087,7 @@
   "performance": {
     "standards-positions": [
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/424",
         "position": "support",
         "concerns": []
@@ -15664,7 +15664,7 @@
     ],
     "standards-positions": [
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/219",
         "concerns": [
           "privacy"
@@ -15739,7 +15739,7 @@
     },
     "standards-positions": [
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/145",
         "concerns": [
           "privacy"
@@ -16283,7 +16283,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/378",
         "position": "",
         "concerns": []
@@ -16905,7 +16905,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/424",
         "position": "support",
         "concerns": []
@@ -17294,7 +17294,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/13",
         "position": "support",
         "concerns": []
@@ -17415,7 +17415,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/63",
         "position": "support",
         "concerns": [
@@ -17603,7 +17603,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/152",
         "position": "support",
         "concerns": []
@@ -17777,7 +17777,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/333",
         "position": "",
         "concerns": []
@@ -17837,7 +17837,7 @@
     },
     "standards-positions": [
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/134",
         "position": "support",
         "concerns": []
@@ -17902,7 +17902,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/135",
         "position": "neutral",
         "concerns": []
@@ -17934,7 +17934,7 @@
     },
     "standards-positions": [
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/133",
         "position": "support",
         "concerns": []
@@ -17966,7 +17966,7 @@
     },
     "standards-positions": [
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/150",
         "position": "support",
         "concerns": []
@@ -18178,7 +18178,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/199",
         "position": "",
         "concerns": []
@@ -18645,7 +18645,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/10",
         "concerns": [],
         "position": ""
@@ -18813,7 +18813,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/258",
         "position": "support",
         "concerns": []
@@ -18864,7 +18864,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/471",
         "position": "",
         "concerns": []
@@ -19391,7 +19391,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/210",
         "position": "support",
         "concerns": []
@@ -19546,7 +19546,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/181",
         "position": "",
         "concerns": []
@@ -19601,7 +19601,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/401",
         "position": "",
         "concerns": []
@@ -19990,7 +19990,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/393",
         "position": "",
         "concerns": []
@@ -20568,7 +20568,7 @@
     },
     "standards-positions": [
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/432",
         "position": "support",
         "concerns": []
@@ -20939,7 +20939,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/143",
         "position": "support",
         "concerns": []
@@ -21078,7 +21078,7 @@
         ]
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/324",
         "position": "",
         "concerns": []
@@ -21416,7 +21416,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/148",
         "position": "support",
         "concerns": []
@@ -21550,7 +21550,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/186",
         "position": "support",
         "concerns": [
@@ -21706,7 +21706,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/70",
         "position": "blocked",
         "concerns": [
@@ -21867,7 +21867,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/61",
         "position": "support",
         "concerns": []
@@ -22048,7 +22048,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/267",
         "position": "oppose",
         "concerns": [
@@ -22106,7 +22106,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/321",
         "position": "support",
         "concerns": []
@@ -22144,7 +22144,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/48",
         "position": "support",
         "concerns": []
@@ -22270,7 +22270,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/16",
         "concerns": [
           "device independence"
@@ -22298,7 +22298,7 @@
   "virtual-pressure-sources": {
     "standards-positions": [
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/255",
         "position": "oppose",
         "concerns": [
@@ -22535,7 +22535,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/4",
         "position": "neutral",
         "concerns": []
@@ -22720,7 +22720,7 @@
   "web-cryptography": {
     "standards-positions": [
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/67",
         "position": "support",
         "concerns": [
@@ -22969,7 +22969,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/240",
         "position": "support",
         "concerns": []
@@ -23448,7 +23448,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/18",
         "position": "support",
         "concerns": []
@@ -23492,7 +23492,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/68",
         "concerns": [
           "privacy",
@@ -23641,7 +23641,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/37",
         "position": "oppose",
         "concerns": [
@@ -23689,7 +23689,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/155",
         "position": "",
         "concerns": []
@@ -23745,7 +23745,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/395",
         "position": "support",
         "concerns": []
@@ -24266,7 +24266,7 @@
         "concerns": []
       },
       {
-        "vendor": "webkit",
+        "vendor": "apple",
         "url": "https://github.com/WebKit/standards-positions/issues/311",
         "position": "support",
         "concerns": []

--- a/mappings/standards-positions.json
+++ b/mappings/standards-positions.json
@@ -7,7 +7,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/166",
       "position": "support",
       "concerns": []
@@ -15,7 +15,7 @@
   ],
   "accelerometer": [
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/347",
       "position": "oppose",
       "concerns": [
@@ -38,7 +38,7 @@
   ],
   "active-view-transition": [
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/266",
       "position": "support",
       "concerns": []
@@ -52,7 +52,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/167",
       "position": "support",
       "concerns": []
@@ -74,7 +74,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/11",
       "position": "neutral",
       "concerns": [
@@ -99,7 +99,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/370",
       "position": "support",
       "concerns": [
@@ -111,7 +111,7 @@
   ],
   "async-iterable-streams": [
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/319",
       "position": "support",
       "concerns": []
@@ -141,7 +141,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/180",
       "concerns": [],
       "position": ""
@@ -149,7 +149,7 @@
   ],
   "background-clip-border-area": [
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/379",
       "position": "support",
       "concerns": []
@@ -163,7 +163,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/149",
       "concerns": [
         "privacy",
@@ -188,7 +188,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/118",
       "position": "",
       "concerns": []
@@ -210,7 +210,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/300",
       "position": "",
       "concerns": []
@@ -224,7 +224,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/348",
       "position": "",
       "concerns": []
@@ -246,7 +246,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/230",
       "position": "blocked",
       "concerns": []
@@ -254,7 +254,7 @@
   ],
   "clipboard-custom-format": [
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/43",
       "position": "",
       "concerns": []
@@ -278,7 +278,7 @@
   ],
   "closewatcher": [
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/215",
       "position": "neutral",
       "concerns": []
@@ -286,7 +286,7 @@
   ],
   "colrv1": [
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/415",
       "position": "",
       "concerns": []
@@ -300,7 +300,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/376",
       "position": "support",
       "concerns": []
@@ -314,7 +314,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/255",
       "position": "oppose",
       "concerns": [
@@ -331,7 +331,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/42",
       "position": "support",
       "concerns": [
@@ -355,7 +355,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/205",
       "position": "neutral",
       "concerns": []
@@ -377,7 +377,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/57",
       "position": "support",
       "concerns": []
@@ -407,7 +407,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/36",
       "position": "support",
       "concerns": [
@@ -417,7 +417,7 @@
   ],
   "corner-shape": [
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/229",
       "position": "support",
       "concerns": []
@@ -439,7 +439,7 @@
   ],
   "cross-document-view-transitions": [
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/193",
       "position": "support",
       "concerns": []
@@ -453,7 +453,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/288",
       "position": "",
       "concerns": []
@@ -467,7 +467,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/355",
       "position": "support",
       "concerns": []
@@ -481,7 +481,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/77",
       "position": "support",
       "concerns": []
@@ -505,7 +505,7 @@
       ]
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/386",
       "position": "support",
       "concerns": []
@@ -513,7 +513,7 @@
   ],
   "customized-built-in-elements": [
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/97",
       "position": "oppose",
       "concerns": []
@@ -527,7 +527,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/12",
       "position": "support",
       "concerns": [
@@ -543,7 +543,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/209",
       "position": "support",
       "concerns": []
@@ -557,7 +557,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/328",
       "position": "",
       "concerns": []
@@ -573,7 +573,7 @@
   ],
   "dialog-closedby": [
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/329",
       "position": "support",
       "concerns": []
@@ -587,7 +587,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/147",
       "position": "support",
       "concerns": []
@@ -601,7 +601,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/164",
       "position": "neutral",
       "concerns": [
@@ -617,7 +617,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/301",
       "position": "support",
       "concerns": []
@@ -633,7 +633,7 @@
       ]
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/41",
       "concerns": [
         "portability",
@@ -644,7 +644,7 @@
   ],
   "dom": [
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/375",
       "position": "support",
       "concerns": []
@@ -661,7 +661,7 @@
       ]
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/243",
       "position": "",
       "concerns": []
@@ -683,7 +683,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/84",
       "position": "",
       "concerns": []
@@ -697,7 +697,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/420",
       "concerns": [
         "duplication",
@@ -717,7 +717,7 @@
       "position": ""
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/29",
       "concerns": [
         "API design",
@@ -747,7 +747,7 @@
       ]
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/173",
       "position": "blocked",
       "concerns": []
@@ -761,7 +761,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/85",
       "position": "support",
       "concerns": [
@@ -782,7 +782,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/231",
       "position": "support",
       "concerns": []
@@ -796,7 +796,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/28",
       "position": "oppose",
       "concerns": [
@@ -806,7 +806,7 @@
   ],
   "font-language-override": [
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/556",
       "position": "",
       "concerns": []
@@ -828,7 +828,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/276",
       "position": "",
       "concerns": []
@@ -844,7 +844,7 @@
   ],
   "form-associated-custom-elements": [
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/47",
       "position": "support",
       "concerns": []
@@ -852,7 +852,7 @@
   ],
   "gamepad-vr": [
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/1",
       "position": "support",
       "concerns": [
@@ -868,7 +868,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/444",
       "position": "",
       "concerns": []
@@ -882,7 +882,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/32",
       "position": "oppose",
       "concerns": [
@@ -892,7 +892,7 @@
   ],
   "gyroscope": [
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/347",
       "position": "oppose",
       "concerns": [
@@ -921,7 +921,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/404",
       "position": "support",
       "concerns": []
@@ -935,7 +935,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/246",
       "position": "support",
       "concerns": []
@@ -949,7 +949,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/3",
       "position": "support",
       "concerns": []
@@ -971,7 +971,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/453",
       "position": "",
       "concerns": []
@@ -1003,7 +1003,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/39",
       "position": "support",
       "concerns": []
@@ -1025,7 +1025,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/94",
       "position": "support",
       "concerns": []
@@ -1055,7 +1055,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/348",
       "position": "",
       "concerns": []
@@ -1077,7 +1077,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/264",
       "position": "support",
       "concerns": []
@@ -1099,7 +1099,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/182",
       "concerns": [
         "compatibility",
@@ -1132,7 +1132,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/242",
       "position": "",
       "concerns": []
@@ -1162,7 +1162,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/130",
       "position": "support",
       "concerns": []
@@ -1184,7 +1184,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/283",
       "position": "",
       "concerns": []
@@ -1198,7 +1198,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/52",
       "position": "",
       "concerns": []
@@ -1222,7 +1222,7 @@
   ],
   "masonry": [
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/105",
       "position": "support",
       "concerns": []
@@ -1244,7 +1244,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/124",
       "position": "support",
       "concerns": []
@@ -1252,7 +1252,7 @@
   ],
   "modulepreload": [
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/81",
       "position": "support",
       "concerns": []
@@ -1266,7 +1266,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/187",
       "position": "support",
       "concerns": []
@@ -1280,7 +1280,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/34",
       "position": "support",
       "concerns": []
@@ -1294,7 +1294,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/369",
       "position": "support",
       "concerns": []
@@ -1327,7 +1327,7 @@
       "position": ""
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/292",
       "position": "support",
       "concerns": [
@@ -1343,7 +1343,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/413",
       "position": "support",
       "concerns": []
@@ -1351,7 +1351,7 @@
   ],
   "orientation-sensor": [
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/347",
       "position": "oppose",
       "concerns": [
@@ -1372,7 +1372,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/427",
       "position": "",
       "concerns": []
@@ -1386,7 +1386,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/169",
       "position": "",
       "concerns": []
@@ -1416,7 +1416,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/50",
       "position": "support",
       "concerns": [
@@ -1434,7 +1434,7 @@
   ],
   "performance": [
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/424",
       "position": "support",
       "concerns": []
@@ -1490,7 +1490,7 @@
   ],
   "prefers-reduced-data": [
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/219",
       "concerns": [
         "privacy"
@@ -1508,7 +1508,7 @@
   ],
   "prefers-reduced-transparency": [
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/145",
       "concerns": [
         "privacy"
@@ -1574,7 +1574,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/378",
       "position": "",
       "concerns": []
@@ -1612,7 +1612,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/424",
       "position": "support",
       "concerns": []
@@ -1642,7 +1642,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/13",
       "position": "support",
       "concerns": []
@@ -1656,7 +1656,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/63",
       "position": "support",
       "concerns": [
@@ -1672,7 +1672,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/152",
       "position": "support",
       "concerns": []
@@ -1686,7 +1686,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/333",
       "position": "",
       "concerns": []
@@ -1702,7 +1702,7 @@
   ],
   "scrollbar-color": [
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/134",
       "position": "support",
       "concerns": []
@@ -1716,7 +1716,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/135",
       "position": "neutral",
       "concerns": []
@@ -1724,7 +1724,7 @@
   ],
   "scrollbar-width": [
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/133",
       "position": "support",
       "concerns": []
@@ -1732,7 +1732,7 @@
   ],
   "scrollend": [
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/150",
       "position": "support",
       "concerns": []
@@ -1754,7 +1754,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/199",
       "position": "",
       "concerns": []
@@ -1784,7 +1784,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/10",
       "concerns": [],
       "position": ""
@@ -1798,7 +1798,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/258",
       "position": "support",
       "concerns": []
@@ -1812,7 +1812,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/471",
       "position": "",
       "concerns": []
@@ -1852,7 +1852,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/210",
       "position": "support",
       "concerns": []
@@ -1874,7 +1874,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/181",
       "position": "",
       "concerns": []
@@ -1896,7 +1896,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/401",
       "position": "",
       "concerns": []
@@ -1918,7 +1918,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/393",
       "position": "",
       "concerns": []
@@ -1942,7 +1942,7 @@
   ],
   "text-box": [
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/432",
       "position": "support",
       "concerns": []
@@ -1964,7 +1964,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/143",
       "position": "support",
       "concerns": []
@@ -1992,7 +1992,7 @@
       ]
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/324",
       "position": "",
       "concerns": []
@@ -2006,7 +2006,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/148",
       "position": "support",
       "concerns": []
@@ -2020,7 +2020,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/186",
       "position": "support",
       "concerns": [
@@ -2036,7 +2036,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/70",
       "position": "blocked",
       "concerns": [
@@ -2061,7 +2061,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/61",
       "position": "support",
       "concerns": []
@@ -2083,7 +2083,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/267",
       "position": "oppose",
       "concerns": [
@@ -2104,7 +2104,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/321",
       "position": "support",
       "concerns": []
@@ -2118,7 +2118,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/48",
       "position": "support",
       "concerns": []
@@ -2140,7 +2140,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/16",
       "concerns": [
         "device independence"
@@ -2150,7 +2150,7 @@
   ],
   "virtual-pressure-sources": [
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/255",
       "position": "oppose",
       "concerns": [
@@ -2183,7 +2183,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/4",
       "position": "neutral",
       "concerns": []
@@ -2199,7 +2199,7 @@
   ],
   "web-cryptography": [
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/67",
       "position": "support",
       "concerns": [
@@ -2255,7 +2255,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/240",
       "position": "support",
       "concerns": []
@@ -2301,7 +2301,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/18",
       "position": "support",
       "concerns": []
@@ -2315,7 +2315,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/68",
       "concerns": [
         "privacy",
@@ -2341,7 +2341,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/37",
       "position": "oppose",
       "concerns": [
@@ -2365,7 +2365,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/155",
       "position": "",
       "concerns": []
@@ -2379,7 +2379,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/395",
       "position": "support",
       "concerns": []
@@ -2425,7 +2425,7 @@
       "concerns": []
     },
     {
-      "vendor": "webkit",
+      "vendor": "apple",
       "url": "https://github.com/WebKit/standards-positions/issues/311",
       "position": "support",
       "concerns": []

--- a/schemas.json
+++ b/schemas.json
@@ -216,7 +216,7 @@
           "type": "string",
           "enum": [
             "mozilla",
-            "webkit"
+            "apple"
           ]
         },
         "url": {

--- a/scripts/update-standards-positions-mapping.js
+++ b/scripts/update-standards-positions-mapping.js
@@ -15,7 +15,7 @@
 // Each position object is structured as follows:
 //
 // {
-//   vendor: "mozilla" | "webkit",
+//   vendor: "mozilla" | "apple",
 //   url: "<url>", // The URL of the vendor's issue about the feature.
 //   position: "<position>", // The vendor's position on the feature.
 //   concerns: ["<concern>"], // An array of concerns the vendor has.
@@ -31,7 +31,7 @@
 //       "position": "positive"
 //     },
 //     {
-//       "vendor": "webkit",
+//       "vendor": "apple",
 //       "url": "https://github.com/WebKit/standards-positions/issues/57",
 //       "position": "support"
 //     }
@@ -108,7 +108,7 @@ async function getWebkitPosition(url) {
 
 async function getPosition(vendor, url) {
   switch (vendor) {
-    case "webkit":
+    case "apple":
       return await getWebkitPosition(url);
     case "mozilla":
       return await getMozillaPosition(url);


### PR DESCRIPTION
This change modifies the vendor enum from webkit to apple to be consistent with using the vendor name instead of the engine.

Existing data points have been updated to use the updated enum value. As well as the schemas and the update script.

Fixes #21