### PR TITLE
Update MDN docs for `individual-transforms` properties

### DIFF
--- a/mappings/combined-data.json
+++ b/mappings/combined-data.json
@@ -13357,22 +13357,22 @@
     },
     "mdn-docs": [
       {
-        "slug": "Web/CSS/Reference/Values/transform-function/translate",
-        "title": "translate()",
+        "slug": "Web/CSS/Reference/Properties/translate",
+        "title": "translate",
         "anchor": null,
-        "url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Values/transform-function/translate"
+        "url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/translate"
       },
       {
-        "slug": "Web/CSS/Reference/Values/transform-function/rotate",
-        "title": "rotate()",
+        "slug": "Web/CSS/Reference/Properties/rotate",
+        "title": "rotate",
         "anchor": null,
-        "url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Values/transform-function/rotate"
+        "url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/rotate"
       },
       {
-        "slug": "Web/CSS/Reference/Values/transform-function/scale",
-        "title": "scale()",
+        "slug": "Web/CSS/Reference/Properties/scale",
+        "title": "scale",
         "anchor": null,
-        "url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Values/transform-function/scale"
+        "url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/scale"
       }
     ],
     "chrome-use-counters": {

--- a/mappings/mdn-docs.json
+++ b/mappings/mdn-docs.json
@@ -4095,22 +4095,22 @@
   ],
   "individual-transforms": [
     {
-      "slug": "Web/CSS/Reference/Values/transform-function/translate",
-      "title": "translate()",
+      "slug": "Web/CSS/Reference/Properties/translate",
+      "title": "translate",
       "anchor": null,
-      "url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Values/transform-function/translate"
+      "url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/translate"
     },
     {
-      "slug": "Web/CSS/Reference/Values/transform-function/rotate",
-      "title": "rotate()",
+      "slug": "Web/CSS/Reference/Properties/rotate",
+      "title": "rotate",
       "anchor": null,
-      "url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Values/transform-function/rotate"
+      "url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/rotate"
     },
     {
-      "slug": "Web/CSS/Reference/Values/transform-function/scale",
-      "title": "scale()",
+      "slug": "Web/CSS/Reference/Properties/scale",
+      "title": "scale",
       "anchor": null,
-      "url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Values/transform-function/scale"
+      "url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/scale"
     }
   ],
   "inert": [


### PR DESCRIPTION
From @LeaVerou:

> These links are wrong (they point to the CSS functions, not the properties). They should be:
>
>[translate](https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/translate)
>[rotate](https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/rotate)
>[scale](https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/scale)