### PR TITLE
Add subpath exports for individual mappings and schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,20 @@ And then import the combined data in your code:
 import mappings from "web-features-mappings" with { type: "json" };
 ```
 
+You can also import an individual mapping file by name (without the `.json` extension):
+
+```js
+import bugs from "web-features-mappings/bugs" with { type: "json" };
+import mdnDocs from "web-features-mappings/mdn-docs" with { type: "json" };
+```
+
+The corresponding JSON schemas are exported too: `web-features-mappings/schema` describes the combined data, and `web-features-mappings/schemas` is the collection of per-file schemas.
+
+```js
+import combinedSchema from "web-features-mappings/schema" with { type: "json" };
+import schemas from "web-features-mappings/schemas" with { type: "json" };
+```
+
 ## TODO
 
 * Add mapping to origin trials.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,12 @@
     "url": "git+https://github.com/web-platform-dx/web-features-mappings.git"
   },
   "license": "Apache-2.0",
-  "exports": "./mappings/combined-data.json",
+  "exports": {
+    ".": "./mappings/combined-data.json",
+    "./*": "./mappings/*.json",
+    "./schema": "./combined-schema.gen.json",
+    "./schemas": "./schemas.json"
+  },
   "scripts": {
     "update": "cd scripts && npm run bump && npm run build"
   }


### PR DESCRIPTION
Expands the single default export into an `exports` map so consumers can import individual artifacts, not just the combined blob.

## Exports
- `.` → `mappings/combined-data.json` (unchanged)
- `./*` → `mappings/*.json` — import any mapping by name, e.g. `web-features-mappings/bugs`
- `./schema` → `combined-schema.gen.json` — schema for the combined data
- `./schemas` → `schemas.json` — collection of per-file schemas

```js
import bugs from "web-features-mappings/bugs" with { type: "json" };
import schema from "web-features-mappings/schema" with { type: "json" };
```

README updated to document the new import forms. All paths verified to resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code), reviewed by this human